### PR TITLE
Timeout because of large result set

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -543,7 +543,6 @@ namespace SOAPHound
             if (depth > 100) return; // Prevent going too deep
 
             var results = CountInCache(prefix);
-            Console.WriteLine("Result count: " + results + " prefix: " + prefix);
             if (results == 0){
                 return;
             }
@@ -585,8 +584,6 @@ namespace SOAPHound
                 }
             }
         }
-
-  
 
         public void CreateOutput(List<ADObject> adobjects, string header)
         {


### PR DESCRIPTION
I encountered timeout errors several times in a really large environment when cn=aa* was not enough. Hence the pull request, which always checks for each cn whether the threshold size has been exceeded. If so, a char is appended to the request.
So the program dynamically goes deeper if the result set is too large. (=> cn=aaa*, cn=aaaa* ...)